### PR TITLE
Add GitHub Actions workflow to publish a NuGet package when pushed to master

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,43 @@
+name: .NET
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+        
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Build
+      run: dotnet build --no-restore
+      
+    - name: Test
+      run: dotnet test --no-build --verbosity normal
+      
+    - name: Set version in project file
+      uses: roryprimrose/set-vs-sdk-project-version@v1
+      with:
+        version: 1.${{ github.run_number }}.0
+
+    - name: Publish NuGet
+      uses: rohith/publish-nuget@v2
+      with:
+        PROJECT_FILE_PATH: ./CoreAudio/CoreAudio.csproj
+        VERSION_STATIC: 1.${{ github.run_number }}.0
+        TAG_COMMIT: true
+        NUGET_KEY: ${{ secrets.NUGET_KEY }}
+        INCLUDE_SYMBOLS: true

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,13 +20,10 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
-        
-    - name: Restore dependencies
-      run: dotnet restore
+        dotnet-version: 5.0.x
       
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build ./CoreAudio/CoreAudio.csproj
       
     - name: Test
       run: dotnet test --no-build --verbosity normal
@@ -37,6 +34,7 @@ jobs:
         version: 1.${{ github.run_number }}.0
 
     - name: Publish NuGet
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
       uses: rohith/publish-nuget@v2
       with:
         PROJECT_FILE_PATH: ./CoreAudio/CoreAudio.csproj

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,10 +14,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1
+    
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 3.1.x
         
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,9 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1
-    
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
@@ -41,4 +38,4 @@ jobs:
         VERSION_STATIC: 1.${{ github.run_number }}.0
         TAG_COMMIT: true
         NUGET_KEY: ${{ secrets.NUGET_KEY }}
-        INCLUDE_SYMBOLS: true
+        INCLUDE_SYMBOLS: false

--- a/CoreAudio/CoreAudio.csproj
+++ b/CoreAudio/CoreAudio.csproj
@@ -4,19 +4,14 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyVersion>2020.11.2.36</AssemblyVersion>
     <FileVersion>2020.11.2.36</FileVersion>
+    <LangVersion>9</LangVersion>
+    <Nullable>enable</Nullable>
+    <Title>CoreAudio</Title>
+    <Authors>morphx666</Authors>
+    <Description>Windows CoreAudio wrapper for .NET</Description>
+    <PackageProjectUrl>https://github.com/morphx666/CoreAudio</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/morphx666/CoreAudio</RepositoryUrl>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\Release\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\Release\</OutputPath>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />


### PR DESCRIPTION
This flow will use GitHub Actions (free) to build just the library project and publish it to NuGet under version 1.x.0 where the x is a auto-incremented number.

The workflow needs a secret called NUGET_KEY setup in the repository settings.