### PR TITLE
MMDevice: renaming FriendlyName to DeviceInterfaceFriendlyName and adding DeviceFriendlyName

### DIFF
--- a/CoreAudio/MMDevice.cs
+++ b/CoreAudio/MMDevice.cs
@@ -129,7 +129,7 @@ namespace CoreAudio
             }
         }
 
-        public string FriendlyName
+        public string DeviceInterfaceFriendlyName
         {
             get
             {
@@ -137,6 +137,21 @@ namespace CoreAudio
                     GetPropertyInformation();
                 if (_PropertyStore?.Contains(PKEY.PKEY_DeviceInterface_FriendlyName) ?? false) {
                     return (string?)_PropertyStore?[PKEY.PKEY_DeviceInterface_FriendlyName]?.Value ?? "";
+                }
+
+                return "Unknown";
+            }
+        }
+
+        public string DeviceFriendlyName
+        {
+            get
+            {
+                if (_PropertyStore == null)
+                    GetPropertyInformation();
+                if (_PropertyStore?.Contains(PKEY.PKEY_Device_FriendlyName) ?? false)
+                {
+                    return (string?)_PropertyStore?[PKEY.PKEY_Device_FriendlyName]?.Value ?? "";
                 }
 
                 return "Unknown";


### PR DESCRIPTION
One audio device interface can have several audio devices connected to it.

For example, my Realtek onboard sound chip has two output devices:
1. Realtek Digital Output (Realtek High Definition Audio)
2. Speakers (Realtek High Definition Audio)

Without this fix, it is not possible to differentiate between the them by specifying the device's friendly name. FriendlyName was "Realtek High Definition Audio" for both devices.

I renamed FriendlyName to DeviceInterfaceFriendlyName and added DeviceFriendlyName according to Microsoft’s specification: https://docs.microsoft.com/en-us/windows/win32/coreaudio/device-properties

Cheers!