### PR TITLE
Parameter name hides the actual value.

### DIFF
--- a/CoreAudio/AudioEndpointVolumeCallback.cs
+++ b/CoreAudio/AudioEndpointVolumeCallback.cs
@@ -34,7 +34,7 @@ namespace CoreAudio {
         AudioEndpointVolume parent;
 
         internal AudioEndpointVolumeCallback(AudioEndpointVolume parent) {
-            parent = parent;
+            this.parent = parent;
         }
 
         [PreserveSig]

--- a/CoreAudio/AudioSessionNotification.cs
+++ b/CoreAudio/AudioSessionNotification.cs
@@ -25,10 +25,10 @@ using CoreAudio.Interfaces;
 
 namespace CoreAudio {
     internal class AudioSessionNotification : IAudioSessionNotification {
-        AudioSessionManager2 parent;
+        readonly AudioSessionManager2 parent;
 
         internal AudioSessionNotification(AudioSessionManager2 parent) {
-            parent = parent;
+            this.parent = parent;
         }
 
         [PreserveSig]

--- a/CoreAudio/ControlChangeNotify.cs
+++ b/CoreAudio/ControlChangeNotify.cs
@@ -27,11 +27,11 @@ using CoreAudio.Interfaces;
 
 namespace CoreAudio {
     internal class ControlChangeNotify : IControlChangeNotify, IDisposable {
-        Part parent;
+        readonly Part parent;
         GCHandle rcwHandle;
 
         internal ControlChangeNotify(Part parent) {
-            parent = parent;
+            this.parent = parent;
             rcwHandle = GCHandle.Alloc(this, GCHandleType.Normal);
         }
 

--- a/CoreAudio/Part.cs
+++ b/CoreAudio/Part.cs
@@ -52,11 +52,11 @@ namespace CoreAudio {
             OnPartNotification?.Invoke(this);
         }
 
-        private AudioVolumeLevel GetAudioVolumeLevel() {
+        private AudioVolumeLevel? GetAudioVolumeLevel() {
             return audioVolumeLevel;
         }
 
-        void GetAudioVolumeLevel(AudioVolumeLevel audioVolumeLevel) {
+        void GetAudioVolumeLevel(AudioVolumeLevel? audioVolumeLevel) {
             part.Activate(CLSCTX.ALL, ref RefIId.IIdIAudioVolumeLevel, out var result);
             if(result is IAudioVolumeLevel level) {
                 audioVolumeLevel = new AudioVolumeLevel(level);


### PR DESCRIPTION
 We have to use "this.parent" to prevent mismatch.